### PR TITLE
fix: make options optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridsome-remark-figure-caption",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A gridsome remark plugin to transform markdown image to figure with caption element",
   "main": "src/plugin.js",
   "scripts": {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -30,7 +30,7 @@ module.exports = (options) => {
           return;
         }
 
-        const figure = createNodes(node, options);
+        const figure = createNodes(node, options || {});
 
         node.type = figure.type;
         node.children = figure.children;


### PR DESCRIPTION
Trying to use this plugin in a Docusaurus project and it errors out if I don't pass in an options object.

```
Module build failed (from ../../node_modules/@docusaurus/mdx-loader/lib/index.js):
TypeError: Cannot destructure property 'figureClassName' of 'undefined' as it is undefined.
    at createNodes (/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/gridsome-remark-figure-caption/src/plugin.js:45:5)
    at /Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/gridsome-remark-figure-caption/src/plugin.js:33:24
    at overload (/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/unist-util-visit/index.js:27:12)
    at visit (/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/unist-util-visit-parents/index.js:56:27)
    at visit (/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/unist-util-visit-parents/index.js:67:75)
    at visitParents (/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/unist-util-visit-parents/index.js:29:26)
    at visit (/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/unist-util-visit/index.js:22:3)
    at /Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/gridsome-remark-figure-caption/src/plugin.js:25:5
    at wrapped (/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/trough/wrap.js:25:19)
    at next (/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/trough/index.js:57:24)
```

Adding a default value for options when passing to `createNodes` solves this.

Bumped the version in this PR to `1.2.2`. Not sure how you publish this package. Let me know if I need revert the package bump commit.
